### PR TITLE
Tooltip added for sidemenu subitems & Fix for toggling dark and light theme often selects the nearest text

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1012,6 +1012,7 @@ pre:after {
     -webkit-background-size:cover;
     background-size: cover;
 	cursor: pointer;
+	user-select: none;
 	transition: background-image .15s ease-in-out .15s
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1018,3 +1018,36 @@ pre:after {
 #docsify-darklight-theme p {
 	visibility: hidden
 }
+
+.tooltip {
+	position: relative;
+}
+
+.tooltip .tooltiptext {
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0.3s linear 1s, opacity 0.3s linear 1s;
+	-webkit-transition: visibility 0.3s linear 1s, opacity 0.3s linear 1s;
+	-o-transition: visibility 0.3s linear 1s, opacity 0.3s linear 1s;
+	-moz-transition: visibility 0.3s linear 1s, opacity 0.3s linear 1s;
+	visibility: hidden;
+	background-color: black;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 5px;
+	position: absolute;
+	z-index: 21;
+	bottom: 100%;
+	left: 50%;
+	margin-left: -105px;
+}
+
+.tooltip:hover .tooltiptext {
+	visibility: visible;
+	opacity: 1;
+}
+
+.tooltip .tooltiptext:hover {
+	visibility: hidden;
+}

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -110,6 +110,20 @@ const plugin = (hook, vm) => {
     }
 
     document.getElementById('docsify-darklight-theme').addEventListener('click', function() { themeConfig.defaultTheme === 'light' ? setTheme('dark') : setTheme('light')})
+
+    // Side menu tooltip
+    let title, action;
+    document.querySelectorAll(".sidebar-nav .section-link").forEach(menu => {
+
+      title = menu.innerText;
+      action = menu.getAttribute("href");
+      menu.parentElement.innerHTML = `<div class="tooltip">
+          <span class="tooltiptext">${title}</span>
+          <a class="section-link" href="${action}">${title}</a>
+        </div>`;
+
+    });
+
   })
 }
   


### PR DESCRIPTION
**Tooltip added for sidemenu subitems**

![captured (2)](https://user-images.githubusercontent.com/9389944/82738286-0962a800-9d26-11ea-8744-d14790a809a9.gif)

**Fix for toggling dark and light theme often selects the nearest text**

BEFORE:
![captured (3)](https://user-images.githubusercontent.com/9389944/82744960-ac3f1480-9d6e-11ea-8c9b-d9e3e3c4fd88.gif)

**AFTER:**
![captured (4)](https://user-images.githubusercontent.com/9389944/82744972-c2e56b80-9d6e-11ea-9522-ebcd7d4037ba.gif)
