### PR TITLE
Fix google fonts CSS import syntax for font families

### DIFF
--- a/starter/css/style.css
+++ b/starter/css/style.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=PT+Sans&Source+Sans+Pro&Roboto+Mono&display=swap");
+@import url("https://fonts.googleapis.com/css?family=PT+Sans|Source+Sans+Pro|Roboto+Mono&display=swap");
 * {
 	-webkit-font-smoothing: antialiased;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
reference: https://developers.google.com/fonts/docs/getting_started#specifying_font_families_and_styles_in_a_stylesheet_url